### PR TITLE
Prevent market trading of inactive loan tokens

### DIFF
--- a/contracts/TuiChainController.sol
+++ b/contracts/TuiChainController.sol
@@ -75,6 +75,7 @@ contract TuiChainController is Ownable
     {
         TuiChainLoan loan = new TuiChainLoan({
             _dai: dai,
+            _controller: this,
             _feeRecipient: _feeRecipient,
             _loanRecipient: _loanRecipient,
             _secondsToExpiration: _secondsToExpiration,
@@ -82,8 +83,6 @@ contract TuiChainController is Ownable
             _paymentFeeAttoDaiPerDai: _paymentFeeAttoDaiPerDai,
             _requestedValueAttoDai: _requestedValueAttoDai
             });
-
-        market.allowToken({ _token: loan.getToken() });
 
         loans[loan] = true;
 
@@ -108,6 +107,20 @@ contract TuiChainController is Ownable
         require(loans[_loan]);
 
         _loan.finalize();
+
+        market.removeToken({ _token: _loan.getToken() });
+    }
+
+    /**
+     * Invoked by loan to inform that it became active.
+     */
+    function notifyLoanActivation() external
+    {
+        TuiChainLoan loan = TuiChainLoan(msg.sender);
+
+        require(loans[loan]);
+
+        market.addToken({ _token: loan.getToken() });
     }
 
     /* ---------------------------------------------------------------------- */

--- a/contracts/TuiChainLoan.sol
+++ b/contracts/TuiChainLoan.sol
@@ -3,6 +3,7 @@
 
 pragma solidity ^0.6.0;
 
+import "./TuiChainController.sol";
 import "./TuiChainToken.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -87,6 +88,9 @@ contract TuiChainLoan is Ownable
     // The Dai contract.
     IERC20 private immutable dai;
 
+    // The controller contract.
+    TuiChainController private immutable controller;
+
     address private immutable feeRecipient;
     address private immutable loanRecipient;
     uint256 private immutable expirationTime;
@@ -131,6 +135,7 @@ contract TuiChainLoan is Ownable
      */
     constructor(
         IERC20 _dai,
+        TuiChainController _controller,
         address _feeRecipient,
         address _loanRecipient,
         uint256 _secondsToExpiration,
@@ -140,6 +145,7 @@ contract TuiChainLoan is Ownable
         ) public
     {
         require(_dai != IERC20(0));
+        require(_controller != TuiChainController(0));
         require(_feeRecipient != address(0));
         require(_loanRecipient != address(0));
         require(_secondsToExpiration > 0);
@@ -148,7 +154,8 @@ contract TuiChainLoan is Ownable
             _attoDai: _requestedValueAttoDai
             });
 
-        dai = _dai;
+        dai        = _dai;
+        controller = _controller;
 
         feeRecipient            = _feeRecipient;
         loanRecipient           = _loanRecipient;
@@ -331,6 +338,8 @@ contract TuiChainLoan is Ownable
                 to: feeRecipient,
                 value: fundingFeeAttoDaiPerDai.mul(requestedValueDai)
                 });
+
+            controller.notifyLoanActivation();
         }
     }
 

--- a/contracts/TuiChainMarket.sol
+++ b/contracts/TuiChainMarket.sol
@@ -107,11 +107,21 @@ contract TuiChainMarket is Ownable
     /* ---------------------------------------------------------------------- */
 
     // Add the given token to the set of allowed tokens.
-    function allowToken(TuiChainToken _token) external onlyOwner
+    // Does nothing if the token is already in the set of allowed tokens.
+    function addToken(TuiChainToken _token) external onlyOwner
     {
         require(_token != TuiChainToken(0));
 
         allowedTokens[_token] = true;
+    }
+
+    // Remove the given token to the set of allowed tokens.
+    // Does nothing if the token is not in the set of allowed tokens.
+    function removeToken(TuiChainToken _token) external onlyOwner
+    {
+        require(_token != TuiChainToken(0));
+
+        allowedTokens[_token] = false;
     }
 
     // Set the fee to the given value.
@@ -171,12 +181,14 @@ contract TuiChainMarket is Ownable
 
     /**
      * Remove an existing sell position.
+     *
+     * Note that this function does not check if the token is allowed, to enable
+     * seller to remove sell positions of tokens of loans that have been
+     * finalized.
      */
     function removeSellPosition(TuiChainToken _token) external
     {
         // checks
-
-        require(allowedTokens[_token]);
 
         uint256 amountTokens = sellPositions[_token][msg.sender].amountTokens;
 


### PR DESCRIPTION
This (1) forbids trading of tokens pertaining to loans that are not yet active, and (2) prevents the creation and purchase of sell positions for tokens of finalized loans.