### PR TITLE
Add helpers to build transaction for users

### DIFF
--- a/.idea/runConfigurations/pytest.xml
+++ b/.idea/runConfigurations/pytest.xml
@@ -4,14 +4,14 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/test" />
     <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="_new_keywords" value="&quot;&quot;" />
     <option name="_new_parameters" value="&quot;&quot;" />
-    <option name="_new_additionalArguments" value="&quot;test&quot;" />
+    <option name="_new_additionalArguments" value="&quot;-nauto&quot;" />
     <option name="_new_target" value="&quot;&quot;" />
     <option name="_new_targetType" value="&quot;CUSTOM&quot;" />
     <method v="2" />

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Synopsis of provided types:
   - `LoanIdentifier` - uniquely identifies a loan
   - `LoanPhase(Enum)` - enumeration of the possible phases of a loan
   - `LoanState` - holds the mutable part of a loan's state
-  - `WrongLoanPhaseError(ValueError)` - raised when loan is not in expected phase
 
 - Types providing access to the on-chain infrastructure:
 
@@ -59,6 +58,11 @@ Synopsis of provided types:
   - `Market` - represents an instance of the *market* contract
   - `Loans` - represents a collection of instances of the *loan* contract
   - `Loan` - represents an instance of the *loan* contract
+
+- Helper types for building transactions to be signed and submitted by users:
+
+  - `MarketUserTransactionBuilder` - to build transactions interacting with *market* contracts
+  - `LoanUserTransactionBuilder` - to build transactions interacting with *loan* contracts
 
 Deploy an instance of TuiChain's Ethereum infrastructure with `Controller.deploy()` or connect to an existing controller contract with `Controller()` and go from there.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ extras =
 commands =
     mypy
     black --check setup.py test tuichain_ethereum
-    pytest test
+    pytest -n auto test
 """
 
 # ---------------------------------------------------------------------------- #

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ def generate_contract_module() -> None:
 
         f.write("import typing as _t\n")
 
+        add_contract(f, "DaiMock", include_bytecode=True)
+        add_contract(f, "IERC20")
         add_contract(f, "TuiChainController", include_bytecode=True)
         add_contract(f, "TuiChainLoan")
         add_contract(f, "TuiChainMarket")
@@ -68,7 +70,7 @@ def add_contract(
     stream.write(f"    ABI: _t.ClassVar[_t.List[_t.Any]] = {data['abi']!r}\n")
 
     if include_bytecode:
-        stream.write(f"    BYTECODE: str = {data['bytecode']!r}\n")
+        stream.write(f"    BYTECODE: _t.ClassVar[str] = {data['bytecode']!r}\n")
 
 
 # ---------------------------------------------------------------------------- #
@@ -85,7 +87,14 @@ setuptools.setup(
     python_requires="~=3.8",
     install_requires=["web3~=5.13"],
     extras_require={
-        "test": ["black", "mypy", "pytest", "tox", "web3[tester]~=5.13"]
+        "test": [
+            "black",
+            "mypy",
+            "pytest",
+            "pytest-xdist",
+            "tox",
+            "web3[tester]~=5.13",
+        ]
     },
     include_package_data=True,
     zip_safe=False,  # for compatibility with mypy

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1,0 +1,103 @@
+# ---------------------------------------------------------------------------- #
+
+from __future__ import annotations
+
+import typing as t
+
+import eth_tester
+import pytest
+import web3
+import web3.exceptions
+
+import tuichain_ethereum._test as tui
+
+# ---------------------------------------------------------------------------- #
+
+
+def test_deploy(
+    accounts: t.Sequence[tui.PrivateKey],
+    chain: eth_tester.EthereumTester,
+    dai: tui.DaiMockContract,
+    w3: web3.Web3,
+) -> None:
+    def deploy(market_fee_atto_dai_per_nano_dai: int) -> None:
+
+        transaction = tui.Controller.deploy(
+            provider=w3.provider,
+            master_account_private_key=accounts[0],
+            dai_contract_address=dai.address,
+            market_fee_atto_dai_per_nano_dai=market_fee_atto_dai_per_nano_dai,
+        )
+
+        assert not transaction.is_done()
+
+        chain.mine_block()
+        assert transaction.is_done()
+
+        transaction.get()
+
+    # fail to deploy controller with invalid market fee
+
+    with pytest.raises(
+        ValueError, match="`fee_atto_dai_per_nano_dai` must not be negative"
+    ):
+        deploy(market_fee_atto_dai_per_nano_dai=-1)
+
+    # deploy controller
+
+    deploy(market_fee_atto_dai_per_nano_dai=0)
+    deploy(market_fee_atto_dai_per_nano_dai=10 ** 7)
+
+
+def test_init(
+    accounts: t.Sequence[tui.PrivateKey],
+    controller: tui.Controller,
+    w3: web3.Web3,
+) -> None:
+
+    # connect to existing controller contract as the owner
+
+    tui.Controller(
+        provider=w3.provider,
+        master_account_private_key=accounts[0],
+        contract_address=controller.contract_address,
+    )
+
+    # fail to connect to a existing controller contract without being the owner
+
+    with pytest.raises(ValueError, match="is not the owner of"):
+
+        tui.Controller(
+            provider=w3.provider,
+            master_account_private_key=accounts[1],
+            contract_address=controller.contract_address,
+        )
+
+    # fail to connect to a non-existing controller contract
+
+    with pytest.raises(web3.exceptions.BadFunctionCallOutput):
+
+        tui.Controller(
+            provider=w3.provider,
+            master_account_private_key=accounts[0],
+            contract_address=tui.Address._random(),
+        )
+
+
+def test_chain_id(controller: tui.Controller, w3: web3.Web3) -> None:
+    assert controller.chain_id == w3.eth.chainId
+
+
+def test_contract_address(controller: tui.Controller) -> None:
+    _ = controller.contract_address
+
+
+def test_loans(controller: tui.Controller) -> None:
+    _ = controller.loans
+
+
+def test_market(controller: tui.Controller) -> None:
+    _ = controller.market
+
+
+# ---------------------------------------------------------------------------- #

--- a/test/test_loan.py
+++ b/test/test_loan.py
@@ -5,36 +5,28 @@ from __future__ import annotations
 import eth_tester
 import pytest
 
-import tuichain_ethereum as tui
+import tuichain_ethereum._test as tui
+import util
 
 # ---------------------------------------------------------------------------- #
 
 
-def advance_time(chain: eth_tester.EthereumTester, seconds: int) -> None:
-    chain.time_travel(chain.get_block_by_number()["timestamp"] + seconds)
-    chain.mine_block()
-
-
-def test_get_state(loan: tui.Loan) -> None:
-    loan.get_state()
-
-
 def test_try_expire(
     chain: eth_tester.EthereumTester,
-    loan: tui.Loan,
+    funding_loan: tui.Loan,
 ) -> None:
 
     # try expiring before deadline
 
-    tx = loan.try_expire()
+    tx = funding_loan.try_expire()
     assert tx.is_done()
     assert not tx.get()
 
     # try expiring after deadline
 
-    advance_time(chain, 65)
+    util.advance_time(chain, 65)
 
-    tx = loan.try_expire()
+    tx = funding_loan.try_expire()
     assert not tx.is_done()
 
     chain.mine_block()
@@ -44,10 +36,10 @@ def test_try_expire(
 
 def test_cancel(
     chain: eth_tester.EthereumTester,
-    loan: tui.Loan,
+    funding_loan: tui.Loan,
 ) -> None:
 
-    tx = loan.cancel()
+    tx = funding_loan.cancel()
     assert not tx.is_done()
 
     chain.mine_block()
@@ -55,15 +47,15 @@ def test_cancel(
     tx.get()
 
 
-def test_finalize(loan: tui.Loan) -> None:
+def test_finalize(funding_loan: tui.Loan) -> None:
 
-    tx = loan.finalize()
+    tx = funding_loan.finalize()
     assert tx.is_done()
 
-    with pytest.raises(tui.InvalidLoanPhaseError) as e:
+    with pytest.raises(
+        ValueError, match="Loan is in phase FUNDING, expected ACTIVE"
+    ):
         tx.get()
-
-    assert e.value.observed == tui.LoanPhase.FUNDING
 
 
 # ---------------------------------------------------------------------------- #

--- a/test/test_loan_user_transaction_builder.py
+++ b/test/test_loan_user_transaction_builder.py
@@ -1,0 +1,192 @@
+# ---------------------------------------------------------------------------- #
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+import web3
+import web3.exceptions
+
+import tuichain_ethereum._test as tui
+import util
+
+# ---------------------------------------------------------------------------- #
+
+
+def _invalid_dai_transfers(
+    build: t.Callable[[int], t.Sequence[tui.UserTransaction]],
+) -> None:
+
+    error_message = "`value_atto_dai` must be a positive multiple of 1 Dai"
+
+    with pytest.raises(ValueError, match=error_message):
+        build(-1 * (10 ** 18))
+
+    with pytest.raises(ValueError, match=error_message):
+        build(0)
+
+    with pytest.raises(ValueError, match=error_message):
+        build((10 ** 18) - 1)
+
+    with pytest.raises(ValueError, match=error_message):
+        build((10 ** 18) + 1)
+
+
+def test_provide_funds(
+    accounts: t.Sequence[tui.PrivateKey], funding_loan: tui.Loan, w3: web3.Web3
+) -> None:
+    def provide_funds(value_dai: int) -> None:
+        util.execute_user_transactions(
+            w3=w3,
+            from_address=accounts[2].address,
+            transactions=funding_loan.user_transaction_builder.provide_funds(
+                value_atto_dai=value_dai * (10 ** 18)
+            ),
+        )
+
+    # fail to provide invalid amounts
+
+    _invalid_dai_transfers(
+        lambda v: funding_loan.user_transaction_builder.provide_funds(
+            value_atto_dai=v
+        ),
+    )
+
+    # provide 9999 Dai
+
+    provide_funds(9_999)
+
+    assert funding_loan.get_state().funded_value_atto_dai == 9_999 * (10 ** 18)
+
+    # provide 1 Dai
+
+    provide_funds(1)
+
+    assert funding_loan.get_state().funded_value_atto_dai == 10_000 * (10 ** 18)
+
+
+def test_withdraw_funds(
+    accounts: t.Sequence[tui.PrivateKey], funding_loan: tui.Loan, w3: web3.Web3
+) -> None:
+    def withdraw_funds(value_dai: int) -> None:
+        util.execute_user_transactions(
+            w3=w3,
+            from_address=accounts[2].address,
+            transactions=funding_loan.user_transaction_builder.withdraw_funds(
+                value_atto_dai=value_dai * (10 ** 18)
+            ),
+        )
+
+    # provide 10 thousand Dai
+
+    util.execute_user_transactions(
+        w3=w3,
+        from_address=accounts[2].address,
+        transactions=funding_loan.user_transaction_builder.provide_funds(
+            value_atto_dai=10_000 * (10 ** 18)
+        ),
+    )
+
+    # fail to withdraw invalid amounts
+
+    _invalid_dai_transfers(
+        lambda v: funding_loan.user_transaction_builder.withdraw_funds(
+            value_atto_dai=v
+        ),
+    )
+
+    # withdraw 4999 Dai
+
+    withdraw_funds(4_999)
+
+    assert funding_loan.get_state().funded_value_atto_dai == 5_001 * (10 ** 18)
+
+    # fail to withdraw 6 000 Dai
+
+    with pytest.raises(web3.exceptions.SolidityError):
+        withdraw_funds(6_000)
+
+    assert funding_loan.get_state().funded_value_atto_dai == 5_001 * (10 ** 18)
+
+    # withdraw the remaining 5 001 Dai
+
+    withdraw_funds(5_001)
+
+    assert funding_loan.get_state().funded_value_atto_dai == 0
+
+
+def test_make_payment(
+    accounts: t.Sequence[tui.PrivateKey], active_loan: tui.Loan, w3: web3.Web3
+) -> None:
+    def make_payment(value_dai: int) -> None:
+        util.execute_user_transactions(
+            w3=w3,
+            from_address=accounts[2].address,
+            transactions=active_loan.user_transaction_builder.make_payment(
+                value_atto_dai=value_dai * (10 ** 18)
+            ),
+        )
+
+    # fail to pay invalid amounts
+
+    _invalid_dai_transfers(
+        lambda v: active_loan.user_transaction_builder.make_payment(
+            value_atto_dai=v
+        ),
+    )
+
+    # pay 9999 Dai
+
+    make_payment(9_999)
+
+    assert active_loan.get_state().paid_value_atto_dai == 9_999 * (10 ** 18)
+
+    # pay 1 Dai
+
+    make_payment(1)
+
+    assert active_loan.get_state().paid_value_atto_dai == 10_000 * (10 ** 18)
+
+
+def test_redeem_tokens(
+    accounts: t.Sequence[tui.PrivateKey],
+    finalized_loan: tui.Loan,
+    w3: web3.Web3,
+) -> None:
+    def redeem_tokens(amount_tokens: int) -> None:
+        util.execute_user_transactions(
+            w3=w3,
+            from_address=accounts[2].address,
+            transactions=finalized_loan.user_transaction_builder.redeem_tokens(
+                amount_tokens=amount_tokens
+            ),
+        )
+
+    # fail to redeem invalid amounts
+
+    error_message = "`amount_tokens` must be positive"
+
+    with pytest.raises(ValueError, match=error_message):
+        finalized_loan.user_transaction_builder.redeem_tokens(-1)
+
+    with pytest.raises(ValueError, match=error_message):
+        finalized_loan.user_transaction_builder.redeem_tokens(0)
+
+    # redeem 14999 tokens
+
+    redeem_tokens(14_999)
+
+    # fail to withdraw 6 000 tokens
+
+    with pytest.raises(
+        web3.exceptions.SolidityError, match="burn amount exceeds balance"
+    ):
+        redeem_tokens(6_000)
+
+    # redeem the remaining 5 001 tokens
+
+    redeem_tokens(5_001)
+
+
+# ---------------------------------------------------------------------------- #

--- a/test/test_loans.py
+++ b/test/test_loans.py
@@ -2,26 +2,26 @@
 
 from __future__ import annotations
 
-import secrets
+import pytest
 
-import tuichain_ethereum as tui
+import tuichain_ethereum._test as tui
 
 # ---------------------------------------------------------------------------- #
 
 
 def test_get_all(
     controller: tui.Controller,
-    loan: tui.Loan,
+    funding_loan: tui.Loan,
 ) -> None:
 
     ret = tuple(controller.loans.get_all())
     assert len(ret) == 1
-    assert ret[0].identifier == loan.identifier
+    assert ret[0].identifier == funding_loan.identifier
 
 
-def test_loans_by_recipient(
+def test_get_by_recipient(
     controller: tui.Controller,
-    loan: tui.Loan,
+    funding_loan: tui.Loan,
 ) -> None:
 
     # non-existent loan
@@ -33,29 +33,28 @@ def test_loans_by_recipient(
 
     # existing loan
 
-    ret = tuple(controller.loans.get_by_recipient(loan.recipient_address))
+    ret = tuple(
+        controller.loans.get_by_recipient(funding_loan.recipient_address)
+    )
     assert len(ret) == 1
-    assert ret[0].identifier == loan.identifier
+    assert ret[0].identifier == funding_loan.identifier
 
 
-def test_loan_by_identifier(
+def test_get_by_identifier(
     controller: tui.Controller,
-    loan: tui.Loan,
+    funding_loan: tui.Loan,
 ) -> None:
 
     # non-existent loan
 
-    ret = controller.loans.get_by_identifier(
-        tui.LoanIdentifier(secrets.token_bytes(20))
-    )
-
-    assert ret is None
+    with pytest.raises(ValueError, match=""):
+        controller.loans.get_by_identifier(tui.LoanIdentifier._random())
 
     # existing loan
 
-    ret = controller.loans.get_by_identifier(loan.identifier)
-    assert ret is not None
-    assert ret.identifier == loan.identifier
+    loan = controller.loans.get_by_identifier(funding_loan.identifier)
+
+    assert loan.identifier == funding_loan.identifier
 
 
 # ---------------------------------------------------------------------------- #

--- a/test/test_market.py
+++ b/test/test_market.py
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------- #
+
+from __future__ import annotations
+
+import eth_tester
+import pytest
+
+import tuichain_ethereum._test as tui
+
+# ---------------------------------------------------------------------------- #
+
+
+def test_get_fee_atto_dai_per_nano_dai(controller: tui.Controller) -> None:
+    assert controller.market.get_fee_atto_dai_per_nano_dai() == 10 ** 7
+
+
+def test_set_fee(
+    chain: eth_tester.EthereumTester, controller: tui.Controller
+) -> None:
+    def set_fee(fee_atto_dai_per_nano_dai: int) -> None:
+
+        transaction = controller.market.set_fee(
+            fee_atto_dai_per_nano_dai=fee_atto_dai_per_nano_dai
+        )
+
+        assert not transaction.is_done()
+
+        chain.mine_block()
+
+        assert transaction.is_done()
+        transaction.get()
+
+        assert (
+            controller.market.get_fee_atto_dai_per_nano_dai()
+            == fee_atto_dai_per_nano_dai
+        )
+
+    # fail to set invalid fee
+
+    with pytest.raises(
+        ValueError, match="`fee_atto_dai_per_nano_dai` must not be negative"
+    ):
+        controller.market.set_fee(fee_atto_dai_per_nano_dai=-1)
+
+    # set fee
+
+    set_fee(0)
+    set_fee(10 ** 7)
+
+
+def test_user_transaction_builder(controller: tui.Controller) -> None:
+    _ = controller.market.user_transaction_builder
+
+
+def test_get_all_sell_positions(controller: tui.Controller) -> None:
+    assert not tuple(controller.market.get_all_sell_positions())
+
+
+def test_get_sell_positions_by_loan(
+    controller: tui.Controller, active_loan: tui.Loan
+) -> None:
+
+    assert not tuple(
+        controller.market.get_sell_positions_by_loan(loan=active_loan)
+    )
+
+
+def test_get_sell_positions_by_seller(controller: tui.Controller) -> None:
+
+    assert not tuple(
+        controller.market.get_sell_positions_by_seller(
+            seller_address=tui.Address._random()
+        )
+    )
+
+
+def test_get_sell_position_by_loan_and_seller(
+    controller: tui.Controller, active_loan: tui.Loan
+) -> None:
+
+    assert (
+        controller.market.get_sell_position_by_loan_and_seller(
+            loan=active_loan, seller_address=tui.Address._random()
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------- #

--- a/test/test_market_user_transaction_builder.py
+++ b/test/test_market_user_transaction_builder.py
@@ -1,0 +1,250 @@
+# ---------------------------------------------------------------------------- #
+
+from __future__ import annotations
+
+import pytest
+
+import tuichain_ethereum._test as tui
+
+# ---------------------------------------------------------------------------- #
+
+
+def test_create_sell_position(
+    active_loan: tui.Loan, controller: tui.Controller
+) -> None:
+    def build(amount_tokens: int, price_atto_dai_per_token: int) -> None:
+        controller.market.user_transaction_builder.create_sell_position(
+            loan=active_loan,
+            amount_tokens=amount_tokens,
+            price_atto_dai_per_token=price_atto_dai_per_token,
+        )
+
+    # fail to build transactions to create position with invalid token amounts
+
+    msg = "`amount_tokens` must be positive"
+
+    with pytest.raises(ValueError, match=msg):
+        build(amount_tokens=-1, price_atto_dai_per_token=10 ** 18)
+
+    with pytest.raises(ValueError, match=msg):
+        build(amount_tokens=0, price_atto_dai_per_token=10 ** 18)
+
+    # fail to build transactions to create position with invalid price
+
+    msg = "`price_atto_dai_per_token` must be a positive multiple of 1 nano-Dai"
+
+    with pytest.raises(ValueError, match=msg):
+        build(amount_tokens=1, price_atto_dai_per_token=-1 * (10 ** 18))
+
+    with pytest.raises(ValueError, match=msg):
+        build(amount_tokens=1, price_atto_dai_per_token=0)
+
+    with pytest.raises(ValueError, match=msg):
+        build(amount_tokens=1, price_atto_dai_per_token=(10 ** 18) - 1)
+
+    with pytest.raises(ValueError, match=msg):
+        build(amount_tokens=1, price_atto_dai_per_token=(10 ** 18) + 1)
+
+    # build transactions to create position
+
+    build(amount_tokens=1, price_atto_dai_per_token=10 ** 18)
+
+
+def test_remove_sell_position(
+    active_loan: tui.Loan, controller: tui.Controller
+) -> None:
+
+    # build transactions to create position
+
+    controller.market.user_transaction_builder.remove_sell_position(
+        loan=active_loan
+    )
+
+
+def test_increase_sell_position_amount(
+    active_loan: tui.Loan, controller: tui.Controller
+) -> None:
+
+    builder = controller.market.user_transaction_builder
+
+    def build(increase_amount: int) -> None:
+        builder.increase_sell_position_amount(
+            loan=active_loan, increase_amount=increase_amount
+        )
+
+    # fail to build transactions with invalid increase amount
+
+    msg = "`increase_amount` must be positive"
+
+    with pytest.raises(ValueError, match=msg):
+        build(increase_amount=-1)
+
+    with pytest.raises(ValueError, match=msg):
+        build(increase_amount=0)
+
+    # build transactions to increase amount
+
+    build(increase_amount=1)
+
+
+def test_decrease_sell_position_amount(
+    active_loan: tui.Loan, controller: tui.Controller
+) -> None:
+
+    builder = controller.market.user_transaction_builder
+
+    def build(decrease_amount: int) -> None:
+        builder.decrease_sell_position_amount(
+            loan=active_loan, decrease_amount=decrease_amount
+        )
+
+    # fail to build transactions with invalid decrease amount
+
+    msg = "`decrease_amount` must be positive"
+
+    with pytest.raises(ValueError, match=msg):
+        build(decrease_amount=-1)
+
+    with pytest.raises(ValueError, match=msg):
+        build(decrease_amount=0)
+
+    # build transactions to decrease amount
+
+    build(decrease_amount=1)
+
+
+def test_update_sell_position_price(
+    active_loan: tui.Loan, controller: tui.Controller
+) -> None:
+    def build(new_price_atto_dai_per_token: int) -> None:
+        controller.market.user_transaction_builder.update_sell_position_price(
+            loan=active_loan,
+            new_price_atto_dai_per_token=new_price_atto_dai_per_token,
+        )
+
+    # fail to build transactions with invalid new price
+
+    error_message = (
+        "`new_price_atto_dai_per_token` must be a positive multiple of 1"
+        " nano-Dai"
+    )
+
+    with pytest.raises(ValueError, match=error_message):
+        build(new_price_atto_dai_per_token=-1 * (10 ** 18))
+
+    with pytest.raises(ValueError, match=error_message):
+        build(new_price_atto_dai_per_token=0)
+
+    with pytest.raises(ValueError, match=error_message):
+        build(new_price_atto_dai_per_token=(10 ** 18) - 1)
+
+    with pytest.raises(ValueError, match=error_message):
+        build(new_price_atto_dai_per_token=(10 ** 18) + 1)
+
+    # build transactions to update price
+
+    build(new_price_atto_dai_per_token=10 ** 18)
+
+
+def test_purchase(active_loan: tui.Loan, controller: tui.Controller) -> None:
+    def build(
+        seller_address: tui.Address,
+        amount_tokens: int,
+        price_atto_dai_per_token: int,
+        fee_atto_dai_per_nano_dai: int,
+    ) -> None:
+
+        controller.market.user_transaction_builder.purchase(
+            loan=active_loan,
+            seller_address=seller_address,
+            amount_tokens=amount_tokens,
+            price_atto_dai_per_token=price_atto_dai_per_token,
+            fee_atto_dai_per_nano_dai=fee_atto_dai_per_nano_dai,
+        )
+
+    # fail to build transactions to purchase with invalid token amount
+
+    msg = "`amount_tokens` must be positive"
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=-1,
+            price_atto_dai_per_token=10 ** 18,
+            fee_atto_dai_per_nano_dai=10 ** 7,
+        )
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=0,
+            price_atto_dai_per_token=10 ** 18,
+            fee_atto_dai_per_nano_dai=10 ** 7,
+        )
+
+    # fail to build transactions to purchase with invalid price
+
+    msg = "`price_atto_dai_per_token` must be a positive multiple of 1 nano-Dai"
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=1,
+            price_atto_dai_per_token=-1 * (10 ** 9),
+            fee_atto_dai_per_nano_dai=10 ** 7,
+        )
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=1,
+            price_atto_dai_per_token=0,
+            fee_atto_dai_per_nano_dai=10 ** 7,
+        )
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=1,
+            price_atto_dai_per_token=(10 ** 9) - 1,
+            fee_atto_dai_per_nano_dai=10 ** 7,
+        )
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=1,
+            price_atto_dai_per_token=(10 ** 9) + 1,
+            fee_atto_dai_per_nano_dai=10 ** 7,
+        )
+
+    # fail to build transactions to purchase with invalid fee
+
+    msg = "`fee_atto_dai_per_nano_dai` must not be negative"
+
+    with pytest.raises(ValueError, match=msg):
+        build(
+            seller_address=tui.Address._random(),
+            amount_tokens=1,
+            price_atto_dai_per_token=10 ** 18,
+            fee_atto_dai_per_nano_dai=-1,
+        )
+
+    # build transactions to purchase
+
+    build(
+        seller_address=tui.Address._random(),
+        amount_tokens=1,
+        price_atto_dai_per_token=10 ** 18,
+        fee_atto_dai_per_nano_dai=10 ** 7,
+    )
+
+    build(
+        seller_address=tui.Address._random(),
+        amount_tokens=1,
+        price_atto_dai_per_token=10 ** 9,
+        fee_atto_dai_per_nano_dai=0,
+    )
+
+
+# ---------------------------------------------------------------------------- #

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,67 @@
+# ---------------------------------------------------------------------------- #
+
+from __future__ import annotations
+
+import typing as t
+
+import eth_tester
+import eth_tester.backends.pyevm.main
+import web3
+import web3.contract
+import web3.types
+
+import tuichain_ethereum._test as tui
+
+# ---------------------------------------------------------------------------- #
+
+
+def advance_time(chain: eth_tester.EthereumTester, seconds: int) -> None:
+    chain.time_travel(chain.get_block_by_number()["timestamp"] + seconds)
+    chain.mine_block()
+
+
+def execute_user_transactions(
+    w3: web3.Web3,
+    from_address: tui.Address,
+    transactions: t.Iterable[tui.UserTransaction],
+) -> None:
+
+    assert isinstance(w3.provider, web3.EthereumTesterProvider)
+
+    tester = w3.provider.ethereum_tester
+    assert isinstance(tester, eth_tester.EthereumTester)
+
+    for tx in transactions:
+
+        # create transaction
+
+        params = web3.contract.fill_transaction_defaults(
+            w3,
+            web3.types.TxParams(
+                {
+                    "data": web3.types.HexStr(tx.data),
+                    "from": from_address._checksummed,
+                    "gas": web3.types.Wei(
+                        eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT
+                    ),
+                    "gasPrice": web3.types.Wei(0),
+                    "to": web3.Web3.toChecksumAddress(tx.to),
+                }
+            ),
+        )
+
+        # test the transaction locally to get better error messages
+
+        w3.eth.call(params)
+
+        # execute transaction
+
+        tx_hash = w3.eth.sendTransaction(params)
+
+        tester.mine_block()
+        tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+
+        assert tx_receipt["status"] == 1
+
+
+# ---------------------------------------------------------------------------- #

--- a/truffle/contracts/TuiChainLoan.sol
+++ b/truffle/contracts/TuiChainLoan.sol
@@ -231,6 +231,7 @@ contract TuiChainLoan is Ownable {
      * 1 Dai, and return the given value converted to Dai.
      *
      * @param _attoDai The input value, in atto-Dai
+     *
      * @return _dai The output value, in Dai
      */
     function _attoDaiToPositiveWholeDai(uint256 _attoDai)

--- a/truffle/contracts/TuiChainMarket.sol
+++ b/truffle/contracts/TuiChainMarket.sol
@@ -112,6 +112,7 @@ contract TuiChainMarket is Ownable {
      * 1 nano-Dai, and return the given value converted to nano-Dai.
      *
      * @param _attoDai The input value, in atto-Dai
+     *
      * @return _nanoDai The output value, in nano-Dai
      */
     function _attoDaiToPositiveWholeNanoDai(uint256 _attoDai)
@@ -197,6 +198,7 @@ contract TuiChainMarket is Ownable {
      * Note that sell positions are stored in an unspecified order.
      *
      * @param _index The index of the sell position
+     *
      * @return _token The ERC-20 contract implementing the token that is up for
      *     sale
      * @return _seller The address of the account or contract that put the
@@ -229,6 +231,7 @@ contract TuiChainMarket is Ownable {
      *
      * @param _token The sell position's token
      * @param _seller The sell position's seller
+     *
      * @return _amountTokens The amount of tokens that are up for sale
      * @return _priceAttoDaiPerToken The selling price, in atto-Dai per token
      */

--- a/truffle/contracts/TuiChainMarketLib.sol
+++ b/truffle/contracts/TuiChainMarketLib.sol
@@ -68,6 +68,7 @@ library TuiChainMarketLib {
      * Note that sell positions are stored in an unspecified order.
      *
      * @param _index The index of the sell position
+     *
      * @return _position The sell position
      */
     function at(SellPositions storage _self, uint256 _index)
@@ -83,6 +84,7 @@ library TuiChainMarketLib {
      *
      * @param _token The sell position's token
      * @param _seller The sell position's seller
+     *
      * @return _exists Whether a sell position with the given token and seller
      *     exists
      */
@@ -99,6 +101,7 @@ library TuiChainMarketLib {
      *
      * @param _token The sell position's token
      * @param _seller The sell position's seller
+     *
      * @return _position The sell position with the given token and seller
      */
     function get(
@@ -106,7 +109,10 @@ library TuiChainMarketLib {
         TuiChainToken _token,
         address _seller
     ) internal view returns (SellPosition storage _position) {
-        return _self.values[_self.indices[_token][_seller].sub(1)];
+        return
+            _self.values[
+                _self.indices[_token][_seller].sub(1, "no such sell position")
+            ];
     }
 
     /**
@@ -148,8 +154,8 @@ library TuiChainMarketLib {
     /**
      * Add an existing sell position.
      *
-     * Note that this invalidates storage references to the SellPosition being
-     * removed.
+     * Note that this invalidates all storage references to existing sell
+     * positions.
      *
      * @param _token The sell position's token
      * @param _seller The sell position's seller
@@ -159,7 +165,8 @@ library TuiChainMarketLib {
         TuiChainToken _token,
         address _seller
     ) internal {
-        uint256 index = _self.indices[_token][_seller].sub(1);
+        uint256 index =
+            _self.indices[_token][_seller].sub(1, "no such sell position");
 
         SellPosition storage last = _self.values[_self.values.length - 1];
 

--- a/truffle/contracts/mocks/DaiMock.sol
+++ b/truffle/contracts/mocks/DaiMock.sol
@@ -10,8 +10,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract DaiMock is ERC20 {
     constructor() public ERC20("Dai Stablecoin", "DAI") {}
 
-    function mint(address account, uint256 amount) external {
-        _mint({account: account, amount: amount});
+    function mint(address _account, uint256 _amount) external {
+        _mint({account: _account, amount: _amount});
     }
 }
 

--- a/truffle/package.json
+++ b/truffle/package.json
@@ -1,7 +1,6 @@
 {
     "license": "UNLICENSED",
     "scripts": {
-        "compile": "truffle compile",
         "prettier": "prettier --write 'contracts/**/*.sol' 'test/**/*.js'",
         "prettier-check": "prettier --check 'contracts/**/*.sol' 'test/**/*.js'",
         "solhint": "solhint -w 0 'contracts/**/*.sol'",

--- a/tuichain_ethereum/_market.py
+++ b/tuichain_ethereum/_market.py
@@ -8,6 +8,7 @@ import typing as _t
 
 import eth_utils as _eth_utils
 import web3.contract as _web3_contract
+import web3.exceptions as _web3_exceptions
 
 import tuichain_ethereum._contracts as _tuichain_contracts
 
@@ -40,40 +41,50 @@ class Market:
     """A handle to a market contract."""
 
     __controller: Controller
+    __contract: _web3_contract.Contract
 
     def __init__(self, controller: Controller) -> None:
         """(private, do not use)"""
+
         self.__controller = controller
 
-    @property
-    def _controller(self) -> Controller:
-        """(private, do not use)"""
-        return self.__controller
-
-    @_functools.cached_property
-    def _contract(self) -> _web3_contract.Contract:
-        """(private, do not use)"""
-        return self.__controller._w3.eth.contract(
+        self.__contract = self.__controller._w3.eth.contract(
             address=_eth_utils.to_checksum_address(
                 self.__controller._contract.caller.market()
             ),
             abi=_tuichain_contracts.TuiChainMarket.ABI,
         )
 
+    @property
+    def _controller(self) -> Controller:
+        """(private, do not use)"""
+        return self.__controller
+
+    @property
+    def _contract(self) -> _web3_contract.Contract:
+        """(private, do not use)"""
+        return self.__contract
+
+    @_functools.cached_property
+    def user_transaction_builder(self) -> MarketUserTransactionBuilder:
+        """The user transaction builder for the market."""
+        return MarketUserTransactionBuilder(market=self)
+
     def get_fee_atto_dai_per_nano_dai(self) -> int:
         """Return the current market purchase fee, in atto-Dai per nano-Dai."""
-        return int(self._contract.caller.feeAttoDaiPerNanoDai())
+        return int(self.__contract.caller.feeAttoDaiPerNanoDai())
 
     def set_fee(self, *, fee_atto_dai_per_nano_dai: int) -> Transaction[None]:
         """
         Set the market purchase fee.
 
-        Parameter is keyword-only to prevent mistakes.
+        Currency parameters are keyword-only to prevent mistakes.
 
         This action may use up some ether from the master account.
 
         :param fee_atto_dai_per_nano_dai: the new market purchase fee, in
             atto-Dai per nano-Dai
+
         :return: the corresponding transaction
 
         :raise ValueError: if ``fee_atto_dai_per_nano_dai`` is negative
@@ -84,7 +95,7 @@ class Market:
         assert isinstance(fee_atto_dai_per_nano_dai, int)
 
         if fee_atto_dai_per_nano_dai < 0:
-            raise ValueError("fee_atto_dai_per_nano_dai must not be negative")
+            raise ValueError("`fee_atto_dai_per_nano_dai` must not be negative")
 
         # send transaction
 
@@ -112,7 +123,7 @@ class Market:
 
         # get caller referencing specific block to ensure consistent snapshot
 
-        caller = self._contract.caller(
+        caller = self.__contract.caller(
             block_identifier=self.__controller._w3.eth.blockNumber
         )
 
@@ -134,7 +145,7 @@ class Market:
 
             loan = Loan(
                 controller=self.__controller,
-                loan_contract_address=token_contract.caller.loan(),
+                identifier=LoanIdentifier(token_contract.caller.loan()),
             )
 
             yield SellPosition(
@@ -145,7 +156,7 @@ class Market:
             )
 
     def get_sell_positions_by_loan(
-        self, loan: _t.Union[Loan, LoanIdentifier]
+        self, loan: Loan
     ) -> _t.Iterable[SellPosition]:
         """
         Return an iterable over all existing sell positions offering tokens of
@@ -157,14 +168,12 @@ class Market:
 
         # TODO: implement properly
 
-        assert isinstance(loan, (Loan, LoanIdentifier))
-
-        loan_identifier = loan.identifier if isinstance(loan, Loan) else loan
+        assert isinstance(loan, Loan)
 
         return (
             position
             for position in self.get_all_sell_positions()
-            if position.loan.identifier == loan_identifier
+            if position.loan.identifier == loan.identifier
         )
 
     def get_sell_positions_by_seller(
@@ -189,38 +198,365 @@ class Market:
         )
 
     def get_sell_position_by_loan_and_seller(
-        self, loan: _t.Union[Loan, LoanIdentifier], seller_address: Address
+        self, loan: Loan, seller_address: Address
     ) -> _t.Optional[SellPosition]:
         """Return the sell position offering tokens of the given loan and whose
         seller has the given address, or ``None`` if no such sell position
         exists."""
 
-        assert isinstance(loan, (Loan, LoanIdentifier))
+        assert isinstance(loan, Loan)
         assert isinstance(seller_address, Address)
 
-        actual_loan: Loan
+        try:
 
-        if isinstance(loan, Loan):
-            actual_loan = loan
-        elif loan_obj := self.__controller.loans.get_by_identifier(loan):
-            actual_loan = loan_obj
+            [
+                amount_tokens,
+                price_atto_dai_per_token,
+            ] = self.__contract.caller.getSellPosition(
+                _token=loan.token_contract_address._checksummed,
+                _seller=seller_address._checksummed,
+            )
+
+        except _web3_exceptions.SolidityError as e:
+
+            if "no such sell position" in str(e):
+                return None
+            else:
+                raise
+
         else:
-            return None
 
-        [
-            amount_tokens,
-            price_atto_dai_per_token,
-        ] = self._contract.caller.getSellPosition(
-            _token=actual_loan.token_contract_address,
-            _seller=seller_address._checksummed,
+            return SellPosition(
+                loan=loan,
+                seller_address=seller_address,
+                amount_tokens=int(amount_tokens),
+                price_atto_dai_per_token=int(price_atto_dai_per_token),
+            )
+
+    def __eq__(self, other: _t.Any) -> bool:
+        raise NotImplementedError
+
+    def __hash__(self) -> int:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------- #
+
+
+def _ensure_positive_whole_nano_dai(name: str, atto_dai: int) -> None:
+    """(private, do not use)"""
+
+    assert isinstance(atto_dai, int)
+
+    if atto_dai <= 0 or atto_dai % (10 ** 9) != 0:
+        raise ValueError(f"`{name}` must be a positive multiple of 1 nano-Dai")
+
+
+class MarketUserTransactionBuilder:
+    """Provides functionality to build transactions for users to interact with a
+    loan contract."""
+
+    __market: Market
+
+    def __init__(self, market: Market) -> None:
+        """(private, do not use)"""
+        self.__market = market
+
+    def create_sell_position(
+        self,
+        loan: Loan,
+        amount_tokens: int,
+        *,
+        price_atto_dai_per_token: int,
+    ) -> _t.Sequence[UserTransaction]:
+        """
+        Build a sequence of transactions for a user to create a sell position.
+
+        Currency parameters are keyword-only to prevent mistakes.
+
+        :param loan: the loan whose token the sell position refers to
+        :param amount_tokens: the number of tokens to offer
+        :param price_atto_dai_per_token: the price, in atto-Dai per token
+
+        :return: the sequence of transactions to be submitted by the user
+
+        :raise ValueError: if there already exists a sell position by the user
+            offering tokens of the given loan
+        :raise ValueError: if ``amount_tokens`` is not positive
+        :raise ValueError: if ``price_atto_dai_per_token`` is not a positive
+            multiple of 1 nano-Dai
+        """
+
+        # validate arguments
+
+        assert isinstance(loan, Loan)
+        assert isinstance(amount_tokens, int)
+
+        if amount_tokens <= 0:
+            raise ValueError("`amount_tokens` must be positive")
+
+        _ensure_positive_whole_nano_dai(
+            "price_atto_dai_per_token", price_atto_dai_per_token
         )
 
-        return SellPosition(
-            loan=actual_loan,
-            seller_address=seller_address,
-            amount_tokens=int(amount_tokens),
-            price_atto_dai_per_token=int(price_atto_dai_per_token),
+        # build and return transactions
+
+        return UserTransaction._build_sequence(
+            # set token allowance for User --> Market transfer
+            loan._token_contract.functions.approve(
+                spender=self.__market._contract.address,
+                amount=amount_tokens,
+            ),
+            # create sell position
+            self.__market._contract.functions.createSellPosition(
+                _token=loan.token_contract_address._checksummed,
+                _amountTokens=amount_tokens,
+                _priceAttoDaiPerToken=price_atto_dai_per_token,
+            ),
+            # reset token allowance
+            loan._token_contract.functions.approve(
+                spender=self.__market._contract.address,
+                amount=0,
+            ),
         )
+
+    def remove_sell_position(self, loan: Loan) -> _t.Sequence[UserTransaction]:
+        """
+        Build a sequence of transactions for a user to remove an existing sell
+        position.
+
+        :param loan: the loan whose token the sell position refers to
+
+        :return: the sequence of transactions to be submitted by the user
+
+        :raise ValueError: if there exists no sell position by the user offering
+            tokens of the given loan
+        """
+
+        # validate arguments
+
+        assert isinstance(loan, Loan)
+
+        # build and return transactions
+
+        return UserTransaction._build_sequence(
+            # remove sell position
+            self.__market._contract.functions.removeSellPosition(
+                _token=loan.token_contract_address._checksummed
+            ),
+        )
+
+    def increase_sell_position_amount(
+        self,
+        loan: Loan,
+        increase_amount: int,
+    ) -> _t.Sequence[UserTransaction]:
+        """
+        Build a sequence of transactions for a user to increase the token amount
+        of an existing sell position.
+
+        :param loan: the loan whose token the sell position refers to
+        :param increase_amount: the number of tokens to add to the amount
+            offered by the sell position
+
+        :return: the sequence of transactions to be submitted by the user
+
+        :raise ValueError: if there exists no sell position by the user offering
+            tokens of the given loan
+        :raise ValueError: if ``increase_amount`` is not positive
+        """
+
+        # validate arguments
+
+        assert isinstance(loan, Loan)
+        assert isinstance(increase_amount, int)
+
+        if increase_amount <= 0:
+            raise ValueError("`increase_amount` must be positive")
+
+        # build and return transactions
+
+        return UserTransaction._build_sequence(
+            # set token allowance for User --> Market transfer
+            loan._token_contract.functions.approve(
+                spender=self.__market._contract.address,
+                amount=increase_amount,
+            ),
+            # increase sell position amount
+            self.__market._contract.functions.increaseSellPositionAmount(
+                _token=loan.token_contract_address._checksummed,
+                _increaseAmount=increase_amount,
+            ),
+            # reset token allowance
+            loan._token_contract.functions.approve(
+                spender=self.__market._contract.address,
+                amount=0,
+            ),
+        )
+
+    def decrease_sell_position_amount(
+        self,
+        loan: Loan,
+        decrease_amount: int,
+    ) -> _t.Sequence[UserTransaction]:
+        """
+        Build a sequence of transactions for a user to decrease the token amount
+        of an existing sell position.
+
+        :param loan: the loan whose token the sell position refers to
+        :param decrease_amount: the number of tokens to subtract from the amount
+            offered by the sell position
+
+        :return: the sequence of transactions to be submitted by the user
+
+        :raise ValueError: if there exists no sell position by the user offering
+            tokens of the given loan
+        :raise ValueError: if ``decrease_amount`` is not positive
+        :raise ValueError: if ``decrease_amount`` exceeds the amount of tokens
+            currently offered by the sell position
+        """
+
+        # validate arguments
+
+        assert isinstance(loan, Loan)
+        assert isinstance(decrease_amount, int)
+
+        if decrease_amount <= 0:
+            raise ValueError("`decrease_amount` must be positive")
+
+        # build and return transactions
+
+        return UserTransaction._build_sequence(
+            # decrease sell position amount
+            self.__market._contract.functions.decreaseSellPositionAmount(
+                _token=loan.token_contract_address._checksummed,
+                _decreaseAmount=decrease_amount,
+            ),
+        )
+
+    def update_sell_position_price(
+        self,
+        loan: Loan,
+        *,
+        new_price_atto_dai_per_token: int,
+    ) -> _t.Sequence[UserTransaction]:
+        """
+        Build a sequence of transactions for a user to update the price of an
+        existing sell position.
+
+        Currency parameters are keyword-only to prevent mistakes.
+
+        :param loan: the loan whose token the sell position refers to
+        :param new_price_atto_dai_per_token: the new price, in atto-Dai per
+            token
+
+        :return: the sequence of transactions to be submitted by the user
+
+        :raise ValueError: if there exists no sell position by the user offering
+            tokens of the given loan
+        :raise ValueError: if ``price_atto_dai_per_token`` is not a positive
+            multiple of 1 nano-Dai
+        """
+
+        # validate arguments
+
+        assert isinstance(loan, Loan)
+
+        _ensure_positive_whole_nano_dai(
+            "new_price_atto_dai_per_token", new_price_atto_dai_per_token
+        )
+
+        # build and return transactions
+
+        return UserTransaction._build_sequence(
+            # update sell position price
+            self.__market._contract.functions.updateSellPositionPrice(
+                _token=loan.token_contract_address._checksummed,
+                _newPriceAttoDaiPerToken=new_price_atto_dai_per_token,
+            ),
+        )
+
+    def purchase(
+        self,
+        loan: Loan,
+        seller_address: Address,
+        amount_tokens: int,
+        *,
+        price_atto_dai_per_token: int,
+        fee_atto_dai_per_nano_dai: int,
+    ) -> _t.Sequence[UserTransaction]:
+        """
+        Build a sequence of transactions for a user to purchase tokens from an
+        existing sell position.
+
+        Currency parameters are keyword-only to prevent mistakes.
+
+        :param loan: the loan whose token the sell position refers to
+        :param seller_address: the address of the seller
+        :param amount_tokens: the number of tokens to offer
+        :param price_atto_dai_per_token: the price, in atto-Dai per token
+        :param fee_atto_dai_per_nano_dai: the market purchase fee, in atto-Dai
+            per paid nano-Dai
+
+        :return: the sequence of transactions to be submitted by the user
+
+        :raise ValueError: if there is no such sell position
+        :raise ValueError: if ``amount_tokens`` is not positive
+        :raise ValueError: if ``price_atto_dai_per_token`` is not a positive
+            multiple of 1 nano-Dai
+        :raise ValueError: if ``fee_atto_dai_per_nano_dai`` is negative
+        """
+
+        # validate arguments
+
+        assert isinstance(loan, Loan)
+        assert isinstance(seller_address, Address)
+        assert isinstance(amount_tokens, int)
+        assert isinstance(fee_atto_dai_per_nano_dai, int)
+
+        if amount_tokens <= 0:
+            raise ValueError("`amount_tokens` must be positive")
+
+        _ensure_positive_whole_nano_dai(
+            "price_atto_dai_per_token", price_atto_dai_per_token
+        )
+
+        if fee_atto_dai_per_nano_dai < 0:
+            raise ValueError("`fee_atto_dai_per_nano_dai` must not be negative")
+
+        # build and return transactions
+
+        total_price_atto_dai = price_atto_dai_per_token * amount_tokens
+        fee = fee_atto_dai_per_nano_dai * (total_price_atto_dai // (10 ** 9))
+
+        total_value = total_price_atto_dai + fee
+
+        return UserTransaction._build_sequence(
+            # set Dai allowance for User --> Loan transfer
+            self.__market._controller._dai_contract.functions.approve(
+                spender=self.__market._contract.address,
+                amount=total_value,
+            ),
+            # make payment
+            self.__market._contract.functions.purchase(
+                _token=loan.token_contract_address._checksummed,
+                _seller=seller_address._checksummed,
+                _amountTokens=amount_tokens,
+                _priceAttoDaiPerToken=price_atto_dai_per_token,
+                _feeAttoDaiPerNanoDai=fee_atto_dai_per_nano_dai,
+            ),
+            # reset Dai allowance
+            self.__market._controller._dai_contract.functions.approve(
+                spender=self.__market._contract.address,
+                amount=0,
+            ),
+        )
+
+    def __eq__(self, other: _t.Any) -> bool:
+        raise NotImplementedError
+
+    def __hash__(self) -> int:
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------- #

--- a/tuichain_ethereum/_test.py
+++ b/tuichain_ethereum/_test.py
@@ -1,0 +1,114 @@
+# ---------------------------------------------------------------------------- #
+
+from __future__ import annotations
+
+import functools as _functools
+import typing as _t
+
+import web3 as _web3
+import web3.contract as _web3_contract
+import web3.providers as _web3_providers
+import web3.types as _web3_types
+
+import tuichain_ethereum._contracts as _tuichain_contracts
+from tuichain_ethereum import *
+
+# ---------------------------------------------------------------------------- #
+
+
+class DaiMockContract:
+    """(private, do not use)"""
+
+    @classmethod
+    def deploy(
+        cls,
+        provider: _web3_providers.BaseProvider,
+        account_private_key: PrivateKey,
+    ) -> Transaction[DaiMockContract]:
+        """(private, do not use)"""
+
+        assert isinstance(provider, _web3_providers.BaseProvider)
+        assert isinstance(account_private_key, PrivateKey)
+
+        w3 = _web3.Web3(provider=provider)
+        w3.enable_strict_bytes_type_checking()
+
+        contract = w3.eth.contract(
+            abi=_tuichain_contracts.DaiMock.ABI,
+            bytecode=_tuichain_contracts.DaiMock.BYTECODE,
+        )
+
+        tx_hash = account_private_key._transact(w3, contract.constructor())
+
+        def on_success(receipt: _web3_types.TxReceipt) -> DaiMockContract:
+
+            assert receipt["contractAddress"] is not None
+
+            return DaiMockContract(
+                provider=provider,
+                account_private_key=account_private_key,
+                contract_address=Address(receipt["contractAddress"]),
+            )
+
+        return Transaction._real(w3=w3, tx_hash=tx_hash, on_success=on_success)
+
+    __w3: _web3.Web3
+    __account: PrivateKey
+    __contract: _web3_contract.Contract
+
+    def __init__(
+        self,
+        provider: _web3_providers.BaseProvider,
+        account_private_key: PrivateKey,
+        contract_address: Address,
+    ) -> None:
+        """(private, do not use)"""
+
+        assert isinstance(provider, _web3_providers.BaseProvider)
+        assert isinstance(account_private_key, PrivateKey)
+        assert isinstance(contract_address, Address)
+
+        self.__w3 = _web3.Web3(provider=provider)
+        self.__w3.enable_strict_bytes_type_checking()
+
+        self.__w3.eth.defaultAccount = (
+            account_private_key.address._checksummed  # type: ignore
+        )
+
+        self.__account = account_private_key
+
+        self.__contract = self.__w3.eth.contract(
+            address=contract_address._checksummed,
+            abi=_tuichain_contracts.DaiMock.ABI,
+        )
+
+    @_functools.cached_property
+    def address(self) -> Address:
+        """(private, do not use)"""
+        return Address(self.__contract.address)
+
+    def mint(
+        self, account_address: Address, atto_dai: int
+    ) -> Transaction[None]:
+        """(private, do not use)"""
+
+        tx_hash = self.__account._transact(
+            self.__w3,
+            self.__contract.functions.mint(
+                _account=account_address._checksummed,
+                _amount=atto_dai,
+            ),
+        )
+
+        return Transaction._real(
+            w3=self.__w3, tx_hash=tx_hash, on_success=lambda _: None
+        )
+
+    def __eq__(self, other: _t.Any) -> bool:
+        raise NotImplementedError
+
+    def __hash__(self) -> int:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------- #


### PR DESCRIPTION
This adds "user transaction builder" types for loan and market contracts providing functionality to build transactions to be signed and submitted directly by a user. The motivation is that the backend would nevertheless have to provide enough information for the frontend to build the transactions itself. By also having the backend doing this last step of constructing the transactions, we avoid the need to embed contract ABIs in the frontend code.

Also sneak in some cleanups and improvements to tests.