### PR TITLE
Don't install development dependencies when installing the Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ def generate_contract_module() -> None:
 
     # install dependencies
 
-    subprocess.run(["npm", "install"], cwd="truffle", check=True)
+    subprocess.run(
+        ["npm", "install", "--production"], cwd="truffle", check=True
+    )
 
     # compile contracts
 


### PR DESCRIPTION
Avoid installing unnecessary development dependencies of the Truffle setup when installing the tuichain_ethereum Python package.