### PR TITLE
Remove the Ropsten Dai contract address constant

### DIFF
--- a/tuichain_ethereum/_base.py
+++ b/tuichain_ethereum/_base.py
@@ -28,9 +28,6 @@ class Address:
     MAINNET_DAI_CONTRACT: _t.ClassVar[Address]
     """The address of the official Dai contract in the Ethereum mainnet."""
 
-    ROPSTEN_TESTNET_DAI_CONTRACT: _t.ClassVar[Address]
-    """The address of the official Dai contract in the Ropsten testnet."""
-
     @classmethod
     def _random(cls) -> Address:
         """(private, do not use)"""
@@ -88,10 +85,6 @@ class Address:
 
 Address.MAINNET_DAI_CONTRACT = Address(
     "0x6B175474E89094C44Da98b954EedeAC495271d0F"
-)
-
-Address.ROPSTEN_TESTNET_DAI_CONTRACT = Address(
-    "0x31F42841c2db5173425b5223809CF3A38FEde360"
 )
 
 # ---------------------------------------------------------------------------- #

--- a/tuichain_ethereum/_controller.py
+++ b/tuichain_ethereum/_controller.py
@@ -42,10 +42,6 @@ class Controller:
         The ``master_account_private_key`` is currently used for everything,
         from signing and paying transactions to receiving funds.
 
-        Make sure to specify the correct ``dai_contract_address`` for the chain
-        you are deploying to. Constants :const:`Address.MAINNET_DAI_CONTRACT`
-        and :const:`Address.ROPSTEN_TESTNET_DAI_CONTRACT` may be of use.
-
         This action may use up some ether from the master account.
 
         :param provider: specifies the Ethereum client to connect to


### PR DESCRIPTION
There are no faucets for the official Dai contract deployed in the Ropsten network, so it isn't very useful for testing. Remove the Address.ROPSTEN_DAI_CONTRACT class variable.