### PR TITLE
Don't reset user allowances after transfers

### DIFF
--- a/tuichain_ethereum/_loans.py
+++ b/tuichain_ethereum/_loans.py
@@ -685,10 +685,6 @@ class LoanUserTransactionBuilder:
             self.__loan._contract.functions.provideFunds(
                 _valueAttoDai=value_atto_dai
             ),
-            # reset Dai allowance
-            self.__loan._controller._dai_contract.functions.approve(
-                spender=self.__loan._contract.address, amount=0
-            ),
         )
 
     def withdraw_funds(
@@ -730,10 +726,6 @@ class LoanUserTransactionBuilder:
             # withdraw funds from loan contract, returning tokens
             self.__loan._contract.functions.withdrawFunds(
                 _valueAttoDai=value_atto_dai
-            ),
-            # reset token allowance
-            self.__loan._token_contract.functions.approve(
-                spender=self.__loan._contract.address, amount=0
             ),
         )
 
@@ -778,10 +770,6 @@ class LoanUserTransactionBuilder:
             self.__loan._contract.functions.makePayment(
                 _valueAttoDai=value_atto_dai
             ),
-            # reset Dai allowance
-            self.__loan._controller._dai_contract.functions.approve(
-                spender=self.__loan._contract.address, amount=0
-            ),
         )
 
     def redeem_tokens(self, amount_tokens: int) -> _t.Sequence[UserTransaction]:
@@ -818,10 +806,6 @@ class LoanUserTransactionBuilder:
             # return tokens to loan contract, obtaining Dai
             self.__loan._contract.functions.redeemTokens(
                 _amountTokens=amount_tokens
-            ),
-            # reset token allowance
-            self.__loan._token_contract.functions.approve(
-                spender=self.__loan._contract.address, amount=0
             ),
         )
 

--- a/tuichain_ethereum/_market.py
+++ b/tuichain_ethereum/_market.py
@@ -313,11 +313,6 @@ class MarketUserTransactionBuilder:
                 _amountTokens=amount_tokens,
                 _priceAttoDaiPerToken=price_atto_dai_per_token,
             ),
-            # reset token allowance
-            loan._token_contract.functions.approve(
-                spender=self.__market._contract.address,
-                amount=0,
-            ),
         )
 
     def remove_sell_position(self, loan: Loan) -> _t.Sequence[UserTransaction]:
@@ -386,11 +381,6 @@ class MarketUserTransactionBuilder:
             self.__market._contract.functions.increaseSellPositionAmount(
                 _token=loan.token_contract_address._checksummed,
                 _increaseAmount=increase_amount,
-            ),
-            # reset token allowance
-            loan._token_contract.functions.approve(
-                spender=self.__market._contract.address,
-                amount=0,
             ),
         )
 
@@ -544,11 +534,6 @@ class MarketUserTransactionBuilder:
                 _amountTokens=amount_tokens,
                 _priceAttoDaiPerToken=price_atto_dai_per_token,
                 _feeAttoDaiPerNanoDai=fee_atto_dai_per_nano_dai,
-            ),
-            # reset Dai allowance
-            self.__market._controller._dai_contract.functions.approve(
-                spender=self.__market._contract.address,
-                amount=0,
             ),
         )
 


### PR DESCRIPTION
This makes user transaction builders not create a final transaction resetting Dai or token allowances, which simplifies things for the user and avoids the non-negligible cost of an additional transaction.