### PR TITLE
Add extra to install web3 with extra [tester]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,10 @@ setuptools.setup(
             "pytest-xdist",
             "tox",
             "web3[tester]~=5.13",
-        ]
+        ],
+        "web3-test-provider": [
+            "web3[tester]~=5.13",
+        ],
     },
     include_package_data=True,
     zip_safe=False,  # for compatibility with mypy


### PR DESCRIPTION
The current [test] extra also does this but further installs a bunch of other stuff that the backend won't need.